### PR TITLE
Load CORE_RL_magick_.dll on Windows, otherwise InitializeMagick can't be found

### DIFF
--- a/src/cffi/load-foreign-library.lisp
+++ b/src/cffi/load-foreign-library.lisp
@@ -9,3 +9,10 @@
   (t (:default "libGraphicsMagickWand")))
 
 (use-foreign-library graphicsmagick-wand)
+
+;;; InitializeMagick doesn't work on Windows unless its dll is loaded specifically
+#+windows
+(progn
+  (define-foreign-library graphicsmagick
+    (:windows "CORE_RL_magick_.dll"))
+  (use-foreign-library graphicsmagick))


### PR DESCRIPTION
I was using an old version of this library that didn't call "InitializeMagick" and it worked fine for my purposes (resizing images), but today I updated to the new code and started getting an error 'alien function "InitializeMagick" is undefined'. From what I understand this function is not exported when loading CORE_RL_wand_.dll, but I was able to workaround this problem by loading CORE_RL_magick_.dll as well.

I'm not an expert in CFFI or windows DLLs so I'm not sure if this makes any sense, but at least this patch fixes the problem.